### PR TITLE
Updated jiq.json, removed comma on line 13

### DIFF
--- a/bucket/jiq.json
+++ b/bucket/jiq.json
@@ -10,7 +10,7 @@
         "64bit": {
             "url": "https://github.com/fiatjaf/jiq/releases/download/v0.7.2/jiq_windows_amd64.exe#/jiq.exe",
             "hash": "cd0702b45b5eba87c5c26879b5d869f69a871dae4d15052db13dd9191f0e354c"
-        },
+        }
     },
     "bin": "jiq.exe",
     "checkver": "github",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the title above -->
There is a comma on line 13 of jiq.json that is causing an invalid json error when updating your scoop bucket in the scoop app.
<!--
  By opening this PR you confirm that you have searched for similar issues/PRs here already.
  Failing to do so will most likely result in closing of this PR without any explanation.
  It is also mandatory to open a relevant issue (either Package Request or Bug Report) for
  discussion with the maintainers, before creating any new PR.
  Read the contributing guide first to save both your and our time.
-->

Closes #XXXX
<!-- or -->
Relates to #XXXX

- [ ] I have read the [Contributing Guide](https://github.com/ScoopInstaller/.github/blob/main/.github/CONTRIBUTING.md).
